### PR TITLE
Fix error while copying articles

### DIFF
--- a/dca/tl_content.php
+++ b/dca/tl_content.php
@@ -641,7 +641,7 @@ class tl_content_sc extends tl_content
 			if($dc->activeRecord->type == 'colsetStart')
 			{
 				$this->Database->prepare("UPDATE tl_content %s WHERE id=?")
-							->set(array('sc_parent'=>'','sc_childs'=>''))
+							->set(array('sc_parent'=>0,'sc_childs'=>''))
 							->execute($intId);
 			}
 		}

--- a/tl_subcolumnsCallback.php
+++ b/tl_subcolumnsCallback.php
@@ -135,25 +135,26 @@ class tl_subcolumnsCallback extends Backend
 				$sc_parent = $objColstarts->id;
 				$parent = $objColstarts->id;
 				$oldChilds = unserialize($objColstarts->sc_childs);
-				$oldChildParent = $this->Database->prepare("SELECT sc_parent FROM tl_content WHERE id=?")
-											    ->limit(1)
-												->execute($oldChilds[0]);
-				
-				$newChilds = $this->Database->prepare("SELECT id,type FROM tl_content WHERE pid=? AND sc_parent=? AND type != 'colsetStart'")
-												->execute($pid,$oldChildParent->sc_parent);
-				$i=1;
-				while($newChilds->next())
-				{
-					$childs[$parent]['sc_childs'][] = $newChilds->id;
-					$parents[$newChilds->id]['sc_parent'] = $parent;
-					$parents[$newChilds->id]['sc_name'] = $sc_name . ($newChilds->type=="colsetPart" ? '-Part-' . $i : '-End');
-					$parents[$newChilds->id]['sc_sortid'] = $i;
-					$i++;
-				}
-				$childs[$parent]['sc_parent'] = $sc_parent;
-				$childs[$parent]['sc_name'] = $sc_name;
-				sort($childs[$parent]['sc_childs']);
-				
+				if (is_array($oldChilds)) {
+                    			$oldChildParent = $this->Database->prepare("SELECT sc_parent FROM tl_content WHERE id=?")
+                        			->limit(1)
+                        			->execute($oldChilds[0]['id']);
+	
+        			        $newChilds = $this->Database->prepare("SELECT id,type FROM tl_content WHERE pid=? AND sc_parent=? AND type != 'colsetStart'")
+                        			->execute($pid,$oldChildParent->sc_parent);
+                    			$i=1;
+                    			while($newChilds->next())
+                    			{
+                        			$childs[$parent]['sc_childs'][] = $newChilds->id;
+                        			$parents[$newChilds->id]['sc_parent'] = $parent;
+                        			$parents[$newChilds->id]['sc_name'] = $sc_name . ($newChilds->type=="colsetPart" ? '-Part-' . $i : '-End');
+                        			$parents[$newChilds->id]['sc_sortid'] = $i;
+                        			$i++;
+                    			}
+                    			$childs[$parent]['sc_parent'] = $sc_parent;
+                    			$childs[$parent]['sc_name'] = $sc_name;
+                    			sort($childs[$parent]['sc_childs']);
+                		}
 			}
 			
 			foreach($childs as $key=>$child)


### PR DESCRIPTION
We switched to PHP 8.1 and Contao 4.13 and had some issues ti copy articles:

`An exception occurred while executing a query: SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: '' for column `cms_live`.`tl_content`.`sc_parent` at row 1`